### PR TITLE
Add encoder settings and use streamSourceOption in send command

### DIFF
--- a/gstreamer/stream_source.go
+++ b/gstreamer/stream_source.go
@@ -84,7 +84,8 @@ func NewStreamSource(name string, opts ...StreamSourceOption) (*StreamSource, er
 
 	var pay *gst.Element
 	if s.codec == mrtp.H264 {
-		s.encoder, err = gst.NewElement("x264enc")
+		settings := map[string]any{"pass": 5, "speed-preset": 1, "tune": 6, "key-int-max": 10_000}
+		s.encoder, err = gst.NewElementWithProperties("x264enc", settings)
 		if err != nil {
 			return nil, err
 		}

--- a/subcmd/receive.go
+++ b/subcmd/receive.go
@@ -28,10 +28,6 @@ func init() {
 	})
 }
 
-var (
-	udpSrcTraceRTP bool
-)
-
 type Receive struct {
 	receiver *gstreamer.RTPBin
 	sink     gstreamer.RTPSinkBin

--- a/subcmd/send.go
+++ b/subcmd/send.go
@@ -36,7 +36,7 @@ var MakeStreamSource = func(name string) (gstreamer.RTPSourceBin, error) {
 		streamSourceOpts = append(streamSourceOpts, gstreamer.StreamSourceFileSourceLocation(flags.SendVideoFile))
 		streamSourceOpts = append(streamSourceOpts, gstreamer.StreamSourceType(gstreamer.Filesrc))
 	}
-	return gstreamer.NewStreamSource(name)
+	return gstreamer.NewStreamSource(name, streamSourceOpts...)
 }
 
 var (


### PR DESCRIPTION
* add encoder settings for real-time media
* Fix: Send command didn't use the streamSourceOption
* Remove old flag variable