### PR TITLE
Nest rtp packets in a slog logger group

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -38,24 +38,21 @@ func Configure(format Format, level slog.Level, writer io.Writer) {
 }
 
 type RTPLogger struct {
-	logger           *slog.Logger
-	vantagePointName string
+	logger *slog.Logger
 }
 
 func NewRTPLogger(vantagePoint string, logger *slog.Logger) *RTPLogger {
 	if logger == nil {
-		logger = slog.Default()
+		logger = slog.Default().With("vantage-point", vantagePoint).WithGroup("rtp-packet")
 	}
 	return &RTPLogger{
-		logger:           logger,
-		vantagePointName: vantagePoint,
+		logger: logger,
 	}
 }
 
 func (l *RTPLogger) LogRTPPacket(header *rtp.Header, payload []byte, _ interceptor.Attributes) {
 	l.logger.Info(
-		"pad probe received RTP packet",
-		"vantage-point", l.vantagePointName,
+		"rtp packet",
 		"version", header.Version,
 		"padding", header.Padding,
 		"marker", header.Marker,


### PR DESCRIPTION
This will change the logging output so that fields of RTP packets are all in a group which for json means they are all in a nested object, see the example below:

```
{
  "time": "2025-07-24T14:50:02.434991234+02:00",
  "level": "INFO",
  "msg": "rtp packet",
  "vantage-point": "UDPSrc",
  "rtp-packet": {
    "version": 2,
    "padding": false,
    "marker": false,
    "payload-type": 96,
    "sequence-number": 287,
    "timestamp": 1447086651,
    "ssrc": 3725273181,
    "payload-length": 1200
  }
}
```