### PR TITLE
:sparkles: :fire: Expose max target rate and remove unused logging event

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -41,8 +41,9 @@ const (
 	TraceRTPRecvFlag FlagName = "trace-rtp-recv"
 	TraceRTPSendFlag FlagName = "trace-rtp-send"
 
-	CCnadaFlag FlagName = "nada"
-	CCgccFlag  FlagName = "pion-gcc"
+	CCnadaFlag        FlagName = "nada"
+	CCgccFlag         FlagName = "pion-gcc"
+	MaxTragetRateFlag FlagName = "max-target-rate"
 
 	QuicCCFlag FlagName = "quic-cc"
 )
@@ -62,7 +63,8 @@ const (
 
 	defaultLocation = "videotestsrc"
 
-	defaultSinkType = uint(0) // Corresponds to autovideosink
+	defaultSinkType      = uint(0)         // Corresponds to autovideosink
+	defaultMaxTargetRate = uint(3_000_000) // 3 Mbps
 
 	defaultQuicCC = uint(0)
 )
@@ -108,6 +110,9 @@ var (
 	CCnada = false
 
 	CCgcc = false
+
+	// MaxTargetRate is the max target rate in bits per second
+	MaxTargetRate = defaultMaxTargetRate
 
 	QuicCC = defaultQuicCC
 )
@@ -164,8 +169,9 @@ var flags = map[FlagName]flagVar{
 	TraceRTPSendFlag: boolVar(&TraceRTPSend, TraceRTPSendFlag, &TraceRTPSend, "Log outgoing RTP packets"),
 
 	// CC flags
-	CCnadaFlag: boolVar(&CCnada, CCnadaFlag, &CCnada, "Enable NADA congestion control"),
-	CCgccFlag:  boolVar(&CCgcc, CCgccFlag, &CCgcc, "Enable GCC congestion control"),
+	CCnadaFlag:        boolVar(&CCnada, CCnadaFlag, &CCnada, "Enable NADA congestion control"),
+	CCgccFlag:         boolVar(&CCgcc, CCgccFlag, &CCgcc, "Enable GCC congestion control"),
+	MaxTragetRateFlag: uintVar(&MaxTargetRate, MaxTragetRateFlag, &MaxTargetRate, "Set the maximum target rate in bits per second of the congestion controler"),
 
 	// QUIC flags
 	QuicCCFlag: uintVar(&QuicCC, "quic-cc", &QuicCC, "Which quic CC to use. 0: Reno, 1: no CC and no pacer, 2: only pacer"),

--- a/roq/transport.go
+++ b/roq/transport.go
@@ -48,7 +48,7 @@ type Transport struct {
 	mtx                  sync.Mutex
 }
 
-func EnableNADA(initRate, minRate, maxRate int) Option {
+func EnableNADA(initRate, minRate, maxRate uint) Option {
 	return func(t *Transport) error {
 		nadaConfig := nada.Config{
 			MinRate:                  uint64(minRate),

--- a/subcmd/webrtc.go
+++ b/subcmd/webrtc.go
@@ -51,6 +51,7 @@ func (w *WebRTC) Exec(cmd string, args []string) error {
 		flags.TraceRTPSendFlag,
 		flags.CCgccFlag,
 		flags.CCnadaFlag,
+		flags.MaxTragetRateFlag,
 	}...)
 	fs.StringVar(&localPort, "local-port", "8080", "Local port of HTTP signaling server to listen on")
 	fs.StringVar(&remotePort, "remote-port", "8080", "Remote Port of HTTP signaling server to connect to")
@@ -120,10 +121,10 @@ Usage:
 		webrtcOptions = append(webrtcOptions, webrtc.EnableCCFBReceiver())
 	}
 	if flags.CCgcc {
-		webrtcOptions = append(webrtcOptions, webrtc.EnableGCC(750_000, 150_000, 3_000_000))
+		webrtcOptions = append(webrtcOptions, webrtc.EnableGCC(750_000, 150_000, int(flags.MaxTargetRate)))
 	}
 	if flags.CCnada {
-		webrtcOptions = append(webrtcOptions, webrtc.EnableNADA(750_000, 150_000, 3_000_000))
+		webrtcOptions = append(webrtcOptions, webrtc.EnableNADA(750_000, 150_000, flags.MaxTargetRate))
 	}
 	if flags.TraceRTPRecv {
 		webrtcOptions = append(webrtcOptions, webrtc.EnableRTPRecvTraceLogging())
@@ -202,7 +203,7 @@ Usage:
 		// the packet to the correct SSRC (because it cannot read the media SSRC
 		// from a raw RTCP packet. The ScreamTx sender on the other hand,
 		// expects the type set to 0.
-		if err = pipeline.AddRTPSourceStreamGst(0, source, false); err != nil {
+		if err = pipeline.AddRTPSourceStreamGst(0, source); err != nil {
 			return err
 		}
 		if err = pipeline.ReceiveRTCPFrom(rtpSink.RTCPReceiver()); err != nil {

--- a/webrtc/transport.go
+++ b/webrtc/transport.go
@@ -130,7 +130,7 @@ func EnableGCC(initRate, minRate, maxRate int) Option {
 	}
 }
 
-func EnableNADA(initRate, minRate, maxRate int) Option {
+func EnableNADA(initRate, minRate, maxRate uint) Option {
 	return func(t *Transport) error {
 		nadaConfig := nada.Config{
 			MinRate:                  uint64(minRate),
@@ -380,7 +380,6 @@ func (t *Transport) onCCFB(reports []rtpfb.Report) error {
 						Arrival:   pr.Arrival,
 						ECN:       gcc.ECN(pr.ECN),
 					})
-					slog.Info("DELAY_MEASUREMENT", "delay", pr.Arrival.Sub(pr.Departure).Microseconds())
 					if pr.Arrival.After(latestAckedArrival) {
 						latestAckedArrival = pr.Arrival
 						latestAckedDeparture = pr.Departure
@@ -406,7 +405,6 @@ func (t *Transport) onCCFB(reports []rtpfb.Report) error {
 						Arrived:   pr.Arrived,
 						Marked:    pr.ECN == rtcp.ECNCE,
 					})
-					slog.Info("DELAY_MEASUREMENT", "delay", pr.Arrival.Sub(pr.Departure).Microseconds())
 					if pr.Arrival.After(latestAckedArrival) {
 						latestAckedArrival = pr.Arrival
 						latestAckedDeparture = pr.Departure


### PR DESCRIPTION
**Done:**
* Removed logging event *DELAY_MEASUREMENT*
  * event is only logged in webrtc
  * Remove it for consistency (not logged with SCReAM)
  * Calculate delay in analysis with rtp packets anyways
* Remove an old debugging print 
* Expose max target rate
  * relevant for testing NADA
  * affects NADA performance <=> NADA uses max_target_rate in the calculation of rate increases/decreases
* Enabling SCReAM now via option
  * so it is consistent with the other CCs
