### PR TITLE
Expose quic-pacer and only use quic timestamps if necessary

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -57,8 +57,9 @@ const (
 	MaxTragetRateFlag FlagName = "max-target-rate"
 	NadaFeedbackFlag  FlagName = "nada-feedback"
 
-	QuicCCFlag  FlagName = "quic-cc"
-	LogQuicFlag FlagName = "log-quic"
+	QuicCCFlag    FlagName = "quic-cc"
+	QuicPacerFlag FlagName = "quic-pacer"
+	LogQuicFlag   FlagName = "log-quic"
 
 	DataChannelFlag FlagName = "dc"
 )
@@ -116,7 +117,8 @@ var (
 	// MaxTargetRate is the max target rate in bits per second
 	MaxTargetRate = uint(3_000_000) // 3 Mbps
 
-	QuicCC = uint(0)
+	QuicCC    = uint(0)
+	QuicPacer = uint(0)
 
 	LogQuic = false
 )
@@ -189,8 +191,9 @@ var flags = map[FlagName]flagVar{
 	NadaFeedbackFlag:  boolVar(&NadaFeedback, NadaFeedbackFlag, &NadaFeedback, "Send NADA feedback"),
 
 	// QUIC flags
-	QuicCCFlag:  uintVar(&QuicCC, QuicCCFlag, &QuicCC, "Which quic CC to use. 0: Reno, 1: no CC and no pacer, 2: only pacer"),
-	LogQuicFlag: boolVar(&LogQuic, LogQuicFlag, &LogQuic, "Log quic internal events"),
+	QuicCCFlag:    uintVar(&QuicCC, QuicCCFlag, &QuicCC, "Which quic CC to use. 0: Reno, 1: no CC and no pacer, 2: only pacer"),
+	QuicPacerFlag: uintVar(&QuicPacer, QuicPacerFlag, &QuicPacer, "Which quic pacer to use. 0: default, 1: rate based pacer"),
+	LogQuicFlag:   boolVar(&LogQuic, LogQuicFlag, &LogQuic, "Log quic internal events"),
 }
 
 func RegisterInto(fs *flag.FlagSet, names ...FlagName) {

--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/quic-go/quic-go v0.55.0 => github.com/Willi-42/quic-go v0.4.0
+replace github.com/quic-go/quic-go v0.55.0 => github.com/Willi-42/quic-go v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Willi-42/go-nada v0.0.0-20250918135705-6a600030be0b h1:0yhrbZ3OV/j40hUuSVUiXkEJyVSA41GhZ5X2UeZWWOc=
 github.com/Willi-42/go-nada v0.0.0-20250918135705-6a600030be0b/go.mod h1:phbthXW20k81T2WY4cqUD5rWX3sPkXaN2aglf4YO/JM=
-github.com/Willi-42/quic-go v0.4.0 h1:M0jXCDJqp7bR7znK4NiVmQaahaUTX7q/ECluijo1ocs=
-github.com/Willi-42/quic-go v0.4.0/go.mod h1:7PbK6lFszV/BjakcT9AK3+YI/WRTR0mUkrbDxmznVwI=
+github.com/Willi-42/quic-go v0.4.1 h1:feBC3XYg5DmVAXC32qgnqsz7M9TFVwTefXeMIqTlvts=
+github.com/Willi-42/quic-go v0.4.1/go.mod h1:7PbK6lFszV/BjakcT9AK3+YI/WRTR0mUkrbDxmznVwI=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/webrtc/transport.go
+++ b/webrtc/transport.go
@@ -142,6 +142,7 @@ func EnableNADA(initRate, minRate, maxRate uint) Option {
 			StartRate:                uint64(initRate),
 			FeedbackDelta:            uint64(feedbackInterval / time.Millisecond), // convert to ms
 			DeactivateQDelayWrapping: true,
+			RefCongLevel:             15, // ms
 		}
 
 		nada := nada.NewSenderOnly(nadaConfig)


### PR DESCRIPTION
### Done
* Only use timestamps if ether gcc or nada is activated (in quictranpsort)
* expose quic pacer as cli argument
* add refCong config to webrtc nada