### PR TITLE
Fix return on nil error

### DIFF
--- a/data/source.go
+++ b/data/source.go
@@ -135,10 +135,7 @@ func (d *DataBin) startRandomSource() error {
 
 func (d *DataBin) Run() error {
 	if d.useFileSrc {
-		err := d.startFileSource()
-		if err != nil {
-			return err
-		}
+		return d.startFileSource()
 	}
 
 	return d.startRandomSource()


### PR DESCRIPTION
If we don't return, we start the random source after the file source finishes.