### PR TITLE
Fix pacing rates

### DIFF
--- a/gstreamer/stream_source.go
+++ b/gstreamer/stream_source.go
@@ -256,6 +256,8 @@ func (s *StreamSource) SrcPad() (*gst.Pad, error) {
 
 // SetBitrate sets the target bit rate of the encoder
 func (s *StreamSource) SetBitrate(ratebps uint) error {
+	// reduce target rate
+	ratebps = uint(0.9 * float64(ratebps))
 	slog.Info("NEW_TARGET_MEDIA_RATE", "rate", ratebps)
 
 	switch s.codec {

--- a/internal/quictransport/transport.go
+++ b/internal/quictransport/transport.go
@@ -417,7 +417,7 @@ func (t *Transport) feedbackReceiver() {
 			t.SetSourceTargetRate(targetRate)
 
 			// rate for pacer
-			rateByte := uint(float64(targetRate) / 8 * 1.2) // TODO
+			rateByte := uint(float64(targetRate) / 8)
 			t.quicConn.SetPacerRate(rateByte)
 		}
 	}

--- a/webrtc/transport.go
+++ b/webrtc/transport.go
@@ -480,7 +480,7 @@ func (t *Transport) onCCFB(report rtpfb.Report) error {
 			}
 		}
 		if t.pacer != nil {
-			t.pacer.SetRate(t.pc.ID(), int(1.5*float64(tr)))
+			t.pacer.SetRate(t.pc.ID(), int(tr))
 		}
 	}
 


### PR DESCRIPTION
Use the target rate as the pacing rate to avoid overshooting the actual bandwidth, but reduce the media target rate to allow some overhead from the encoder overshooting the target rate.