### PR TITLE
Use only one stream for quic dc and log streamID flowID mapping

### DIFF
--- a/datachannels/receiver.go
+++ b/datachannels/receiver.go
@@ -2,7 +2,6 @@ package datachannels
 
 import (
 	"context"
-	"io"
 
 	"github.com/mengelbart/quicdc"
 )
@@ -29,21 +28,9 @@ func (r *Receiver) Read(buf []byte) (int, error) {
 		}
 	}
 
-	n, err := r.rm.Read(buf)
-	if err != nil {
-		if err == io.EOF {
-			// finished reading this message
-			r.rm = nil
-			return n, nil
-		}
-
-		return n, err
-	}
-
-	return n, nil
+	return r.rm.Read(buf)
 }
 
 func (r *Receiver) Close() error {
-	// TODO: datachannel module currently does not support closing a channel
-	return nil
+	return r.rm.Close()
 }

--- a/datachannels/sender.go
+++ b/datachannels/sender.go
@@ -7,46 +7,35 @@ import (
 )
 
 type Sender struct {
-	dc           *quicdc.DataChannel
-	msgWriteCnt  int
-	maxMsgWrites int
+	dc *quicdc.DataChannel
 
 	mw *quicdc.DataChannelWriteMessage
 }
 
 func newSender(dc *quicdc.DataChannel) *Sender {
 	return &Sender{
-		dc:           dc,
-		maxMsgWrites: 100,
+		dc: dc,
 	}
 }
 
 func (s *Sender) Write(data []byte) (int, error) {
-	if s.mw == nil || s.msgWriteCnt >= s.maxMsgWrites {
-		if s.mw != nil {
-			s.mw.Close()
-		}
-
+	if s.mw == nil {
 		// open new message
 		var err error
 		s.mw, err = s.dc.SendMessage(context.TODO())
 		if err != nil {
 			return 0, err
 		}
-		s.msgWriteCnt = 0
 	}
 
 	n, err := s.mw.Write(data)
 	if err != nil {
 		return n, err
 	}
-	s.msgWriteCnt++
 
 	return n, nil
 }
 
 func (s *Sender) Close() error {
-	// TODO: datachannel module currently does not support closing a channel
-	// at least close current message
 	return s.mw.Close()
 }

--- a/subcmd/receive.go
+++ b/subcmd/receive.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 
@@ -209,6 +210,8 @@ func (r *Receive) setupRoQ() error {
 		roqTransport.HandleDatagram(dgram)
 	}
 	quicConn.HandleUintStream = func(flowID uint64, rs *quic.ReceiveStream) {
+		slog.Info("new uni stream", "streamID", rs.StreamID(), "flowID", flowID)
+
 		if flowID == uint64(flags.RTPFlowID) || flowID == uint64(flags.RTCPRecvFlowID) || flowID == uint64(flags.RTCPSendFlowID) {
 			roqTransport.HandleUniStreamWithFlowID(flowID, roqProtocol.NewQuicGoReceiveStream(rs))
 			return


### PR DESCRIPTION
* only use a single quic stream for a single datachannel
* log mapping of streamID and flowID on reciever