### PR TITLE
:sparkles:Multiply rtp flows over ROQ

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -28,6 +28,7 @@ const (
 	RTPPortFlag      FlagName = "rtp-port"
 	RTCPRecvPortFlag FlagName = "rtcp-recv-porto"
 	RTCPSendPortFlag FlagName = "rtcp-send-porto"
+	RTPFlowsFlag     FlagName = "rtp-flows"
 
 	RTPFlowIDFlag          FlagName = "rtp-flow-id"
 	RTCPRecvFlowIDFlag     FlagName = "rtcp-recv-flow-id"
@@ -88,6 +89,7 @@ var (
 	RTPPort      = uint(5000)
 	RTCPSendPort = uint(5001)
 	RTCPRecvPort = uint(5002)
+	RTPFlows     = uint(1)
 
 	// Flow IDs for RoQ and datachannels
 	RTPFlowID          = uint(0)
@@ -159,13 +161,14 @@ var flags = map[FlagName]flagVar{
 	RTPPortFlag:      uintVar(&RTPPort, RTPPortFlag, &RTPPort, "UDP Port number for outgoing RTP stream"),
 	RTCPRecvPortFlag: uintVar(&RTCPRecvPort, RTCPRecvPortFlag, &RTCPRecvPort, "UDP port for incoming RTCP stream"),
 	RTCPSendPortFlag: uintVar(&RTCPSendPort, RTCPSendPortFlag, &RTCPSendPort, "UDP port for outgoing RTCP stream"),
+	RTPFlowsFlag:     uintVar(&RTPFlows, RTPFlowsFlag, &RTPFlows, "Number of RTP flows to be sent/received. FlowIDs := baseID + i*10"),
 
 	// flow ID flags
-	RTPFlowIDFlag:          uintVar(&RTPFlowID, RTPFlowIDFlag, &RTPFlowID, "RTP Flow ID when using RTP over QUIC"),
-	RTCPRecvFlowIDFlag:     uintVar(&RTCPRecvFlowID, RTCPRecvFlowIDFlag, &RTCPRecvFlowID, "RTP Flow ID when using RTP over QUIC"),
-	RTCPSendFlowIDFlag:     uintVar(&RTCPSendFlowID, RTCPSendFlowIDFlag, &RTCPSendFlowID, "RTP Flow ID when using RTP over QUIC"),
-	DataChannelFlowIDFlag:  uintVar(&DataChannelFlowID, DataChannelFlowIDFlag, &DataChannelFlowID, "Data Channel Flow ID when using quic data channels"),
-	NadaFeedbackFlowIDFlag: uintVar(&NadaFeedbackFlowID, NadaFeedbackFlowIDFlag, &NadaFeedbackFlowID, "NADA Feedback Flow ID when using NADA or GCC with QUIC"),
+	RTPFlowIDFlag:          uintVar(&RTPFlowID, RTPFlowIDFlag, &RTPFlowID, "RTP Flow ID when using RTP over QUIC. Single Digit!"),
+	RTCPRecvFlowIDFlag:     uintVar(&RTCPRecvFlowID, RTCPRecvFlowIDFlag, &RTCPRecvFlowID, "RTP Flow ID when using RTP over QUIC. Single Digit!"),
+	RTCPSendFlowIDFlag:     uintVar(&RTCPSendFlowID, RTCPSendFlowIDFlag, &RTCPSendFlowID, "RTP Flow ID when using RTP over QUIC. Single Digit!"),
+	DataChannelFlowIDFlag:  uintVar(&DataChannelFlowID, DataChannelFlowIDFlag, &DataChannelFlowID, "Data Channel Flow ID when using quic data channels. Single Digit!"),
+	NadaFeedbackFlowIDFlag: uintVar(&NadaFeedbackFlowID, NadaFeedbackFlowIDFlag, &NadaFeedbackFlowID, "NADA Feedback Flow ID when using NADA or GCC with QUIC. Single Digit!"),
 
 	// TLS Certificate
 	CertFlag: stringVar(&Cert, CertFlag, &Cert, "TLS Certificate"),

--- a/subcmd/send.go
+++ b/subcmd/send.go
@@ -149,6 +149,12 @@ Flags:
 		os.Exit(1)
 	}
 
+	if flags.DataChannelFlowID > 9 || flags.RTCPSendFlowID > 9 || flags.RTCPRecvFlowID > 9 || flags.RTPFlowID > 9 {
+		fmt.Fprintf(os.Stderr, "Flow IDs must be between 0 and 9 to allowd for multiple flows.\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+
 	if (flags.CCnada || flags.CCgcc || flags.QuicCC != 0 || flags.QuicPacer != 0 || flags.LogQuic || flags.RoQMapping != 0) && (!flags.RoQServer && !flags.RoQClient) {
 		fmt.Fprintf(os.Stderr, "Flags -%v, -%v, -%v, -%v and -%v are only valid for RoQ\n", flags.CCnadaFlag, flags.CCgccFlag, flags.QuicCCFlag, flags.LogQuicFlag, flags.RoQMappingFlag)
 		fs.Usage()

--- a/subcmd/send.go
+++ b/subcmd/send.go
@@ -300,7 +300,7 @@ func runRoqPipe() error {
 			return err
 		}
 
-		dataSource, err = createDataSource(dcSender, flags.DcSourceFile, flags.DcStartDelay, false)
+		dataSource, err = createDataSource(dcSender, flags.DcSourceFile, flags.DcStartDelay)
 		if err != nil {
 			return err
 		}

--- a/subcmd/webrtc.go
+++ b/subcmd/webrtc.go
@@ -106,7 +106,7 @@ Usage:
 		webrtc.SetSRTPBufferLimit(10_000_000), // 10MB
 		webrtc.RegisterDefaultCodecs(),
 		webrtc.OnTrack(func(receiver *webrtc.RTPReceiver) {
-			sink, newSinkErr := DefaultStreamSinkFactory.MakeStreamSink("rtp-stream-sink", int(receiver.PayloadType()), "out.y4m", 0)
+			sink, newSinkErr := DefaultStreamSinkFactory.MakeStreamSink("rtp-stream-sink", int(receiver.PayloadType()), flags.SinkLocation, 0)
 			if newSinkErr != nil {
 				panic(err)
 			}
@@ -193,7 +193,7 @@ Usage:
 	if offer && flags.DataChannel {
 		dcSender := transport.NewDataChannelSender("data")
 		var dataSource *data.DataBin
-		dataSource, err = createDataSource(dcSender, flags.DcSourceFile, flags.DcStartDelay, false)
+		dataSource, err = createDataSource(dcSender, flags.DcSourceFile, flags.DcStartDelay)
 		if err != nil {
 			return err
 		}

--- a/subcmd/webrtc.go
+++ b/subcmd/webrtc.go
@@ -147,10 +147,10 @@ Usage:
 		webrtcOptions = append(webrtcOptions, webrtc.EnablePacing())
 	}
 	if flags.CCgcc {
-		webrtcOptions = append(webrtcOptions, webrtc.EnableGCC(750_000, 150_000, int(flags.MaxTargetRate)))
+		webrtcOptions = append(webrtcOptions, webrtc.EnableGCC(750_000, 250_000, int(flags.MaxTargetRate)))
 	}
 	if flags.CCnada {
-		webrtcOptions = append(webrtcOptions, webrtc.EnableNADA(750_000, 150_000, flags.MaxTargetRate))
+		webrtcOptions = append(webrtcOptions, webrtc.EnableNADA(750_000, 250_000, flags.MaxTargetRate))
 	}
 
 	connectedCtx, cancelConnectedCtx := context.WithCancel(context.Background())

--- a/subcmd/webrtc.go
+++ b/subcmd/webrtc.go
@@ -106,7 +106,7 @@ Usage:
 		webrtc.SetSRTPBufferLimit(10_000_000), // 10MB
 		webrtc.RegisterDefaultCodecs(),
 		webrtc.OnTrack(func(receiver *webrtc.RTPReceiver) {
-			sink, newSinkErr := DefaultStreamSinkFactory.MakeStreamSink("rtp-stream-sink", int(receiver.PayloadType()))
+			sink, newSinkErr := DefaultStreamSinkFactory.MakeStreamSink("rtp-stream-sink", int(receiver.PayloadType()), "out.y4m", 0)
 			if newSinkErr != nil {
 				panic(err)
 			}
@@ -210,7 +210,7 @@ Usage:
 
 	if sendVideoTrack {
 		var source gstreamer.RTPSourceBin
-		source, err = DefaultStreamSourceFactory.MakeStreamSource("rtp-stream-source")
+		source, err = DefaultStreamSourceFactory.MakeStreamSource("rtp-stream-source", 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`-rtp-flows X` on sender and receiver to send/receive multiple flows
* uses `flowID := RTPFlowIDFlag * i*10` as flowID for flow i

Additional:
* Use pacer instead of rate limited data in send_data command

**Issues**
* plot to differentiate the flows in the network only work with streams
