### PR TITLE
:zap:Improve send queue and x264enc settings

### DIFF
--- a/subcmd/send.go
+++ b/subcmd/send.go
@@ -219,14 +219,13 @@ Flags:
 			quictransport.WithPacer(int(flags.QuicPacer)),
 		}
 
-		initRate := 750_000 * (100 - dcPercatage) / 100
 		if flags.CCnada {
 			feedbackDelta := uint64(20)
-			quicOptions = append(quicOptions, quictransport.EnableNADA(initRate, 150_000, flags.MaxTargetRate, uint(feedbackDelta), uint64(flags.NadaFeedbackFlowID)))
+			quicOptions = append(quicOptions, quictransport.EnableNADA(750_000, 150_000, flags.MaxTargetRate, uint(feedbackDelta), uint64(flags.NadaFeedbackFlowID)))
 		}
 
 		if flags.CCgcc {
-			quicOptions = append(quicOptions, quictransport.EnableGCC(int(initRate), 150_000, int(flags.MaxTargetRate), uint64(flags.NadaFeedbackFlowID)))
+			quicOptions = append(quicOptions, quictransport.EnableGCC(750_000, 150_000, int(flags.MaxTargetRate), uint64(flags.NadaFeedbackFlowID)))
 		}
 		if flags.LogQuic {
 			quicOptions = append(quicOptions, quictransport.EnableQLogs("./sender.qlog"))


### PR DESCRIPTION
* double default send queue limits
* Do not reduced NADAs init rate if dc is active
  * has nothing to do with the overall rate 

**x264enc**
* ` key-int-max` to auto. Was 10,000 frames
* set init bitrate