### PR TITLE
:bug:Set codec variable in both stream factories

### DIFF
--- a/subcmd/receive.go
+++ b/subcmd/receive.go
@@ -30,6 +30,7 @@ var UDPRecvBufferSize int
 type StreamSinkFactory interface {
 	ConfigureFlags(*flag.FlagSet)
 	MakeStreamSink(name string, payloadType int) (gstreamer.RTPSinkBin, error)
+	Codec() string
 }
 
 type gstreamerVideoStreamSinkFactory struct {
@@ -46,6 +47,10 @@ func (f *gstreamerVideoStreamSinkFactory) ConfigureFlags(fs *flag.FlagSet) {
 	if fs.Lookup("codec") == nil {
 		fs.StringVar(&f.codec, "codec", mrtp.H264.String(), "Codec to use (H264, VP8)")
 	}
+}
+
+func (f *gstreamerVideoStreamSinkFactory) Codec() string {
+	return f.codec
 }
 
 func (f *gstreamerVideoStreamSinkFactory) MakeStreamSink(name string, pt int) (gstreamer.RTPSinkBin, error) {

--- a/subcmd/send.go
+++ b/subcmd/send.go
@@ -35,6 +35,7 @@ type BitrateAdapter interface {
 type StreamSourceFactory interface {
 	ConfigureFlags(*flag.FlagSet)
 	MakeStreamSource(name string) (gstreamer.RTPSourceBin, error)
+	SetCodec(codec string)
 }
 
 type gstreamerVideoStreamSourceFactory struct {
@@ -51,6 +52,8 @@ func (f *gstreamerVideoStreamSourceFactory) ConfigureFlags(fs *flag.FlagSet) {
 }
 
 func (f *gstreamerVideoStreamSourceFactory) MakeStreamSource(name string) (gstreamer.RTPSourceBin, error) {
+	fmt.Printf("codec to be used: '%v', location: %v\n", f.codec, f.sourceLocation)
+
 	codec, error := mrtp.NewCodec(f.codec)
 	if error != nil {
 		return nil, error
@@ -68,6 +71,10 @@ func (f *gstreamerVideoStreamSourceFactory) MakeStreamSource(name string) (gstre
 		streamSourceOpts = append(streamSourceOpts, gstreamer.StreamSourceType(gstreamer.Filesrc))
 	}
 	return gstreamer.NewStreamSource(name, streamSourceOpts...)
+}
+
+func (f *gstreamerVideoStreamSourceFactory) SetCodec(codec string) {
+	f.codec = codec
 }
 
 var DefaultStreamSourceFactory StreamSourceFactory = &gstreamerVideoStreamSourceFactory{}

--- a/subcmd/webrtc.go
+++ b/subcmd/webrtc.go
@@ -103,6 +103,9 @@ Usage:
 	}
 	fs.Parse(args)
 
+	// workaround: codec flag is only registered in sink
+	DefaultStreamSourceFactory.SetCodec(DefaultStreamSinkFactory.Codec())
+
 	pipeline, err := gstreamer.NewRTPBin()
 	if err != nil {
 		return err


### PR DESCRIPTION
Because we no longer use the global flag package, the codec for `DefaultStreamSourceFactory` in webrtc was never set.
