### PR TITLE
:bug: Fix stuck goroutine in synctests

### DIFF
--- a/gopipe/frame_spacer.go
+++ b/gopipe/frame_spacer.go
@@ -16,7 +16,16 @@ type FrameSpacer struct {
 	frameDuration time.Duration
 	pktChan       chan packets
 
-	Ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewFrameSpacer(ctx context.Context) *FrameSpacer {
+	spacerCtx, cancel := context.WithCancel(ctx)
+	return &FrameSpacer{
+		ctx:    spacerCtx,
+		cancel: cancel,
+	}
 }
 
 func (p *FrameSpacer) Link(w Sink, i Info) (Sink, error) {
@@ -44,7 +53,7 @@ func (p *FrameSpacer) WriteAll(pkts [][]byte, attr Attributes) error {
 func (p *FrameSpacer) run() {
 	for {
 		select {
-		case <-p.Ctx.Done():
+		case <-p.ctx.Done():
 			return
 		case pkts := <-p.pktChan:
 			if len(p.pktChan) > 2 {
@@ -63,7 +72,7 @@ func (p *FrameSpacer) run() {
 			var next []byte
 			for range ticker.C {
 				select {
-				case <-p.Ctx.Done():
+				case <-p.ctx.Done():
 					return
 				default:
 				}
@@ -78,4 +87,11 @@ func (p *FrameSpacer) run() {
 			}
 		}
 	}
+}
+
+func (p *FrameSpacer) Close() error {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	return nil
 }

--- a/gopipe/rtp_depacketizer_test.go
+++ b/gopipe/rtp_depacketizer_test.go
@@ -71,9 +71,9 @@ func testDepacketizerWithCodec(t *testing.T, codec codec.CodecType) {
 			ClockRate: 90_000,
 			Codec:     codec,
 		}
-		pacer := &FrameSpacer{
-			Ctx: ctx,
-		}
+		pacer := NewFrameSpacer(ctx)
+		defer pacer.Close()
+
 		frameInter := newFrameInterceptor(false, 0, nil)
 		rtpPipeline, err := Chain(i, sink, pacer, packetizer, encoder, frameInter)
 		assert.NoError(t, err)
@@ -150,9 +150,8 @@ func testDepacketizerFrameIntegrityWithCodec(t *testing.T, codec codec.CodecType
 			ClockRate: 90_000,
 			Codec:     codec,
 		}
-		pacer := &FrameSpacer{
-			Ctx: ctx,
-		}
+		pacer := NewFrameSpacer(ctx)
+		defer pacer.Close()
 
 		frameInter := newFrameInterceptor(true, maxFrames, nil)
 
@@ -253,9 +252,8 @@ func testDepacketizerRTPdropsWithCodec(t *testing.T, codec codec.CodecType) {
 			ClockRate: 90_000,
 			Codec:     codec,
 		}
-		pacer := &FrameSpacer{
-			Ctx: ctx,
-		}
+		pacer := NewFrameSpacer(ctx)
+		defer pacer.Close()
 
 		frameInter := newFrameInterceptor(true, maxFrames, framesToBeDropped)
 		dropInter := newRtpDropInterceptor()

--- a/gopipe/vpx_decoder_test.go
+++ b/gopipe/vpx_decoder_test.go
@@ -124,9 +124,9 @@ func runVpxDecodeWithRTP(t *testing.T, c codec.CodecType) {
 			ClockRate: 90_000,
 			Codec:     c,
 		}
-		pacer := &FrameSpacer{
-			Ctx: ctx,
-		}
+		pacer := NewFrameSpacer(ctx)
+		defer pacer.Close()
+
 		frameInter := newFrameInterceptor(false, 0, nil)
 
 		writer, err := Chain(i, sink, pacer, packetizer, encoder, frameInter)

--- a/gopipe/x264_decoder_test.go
+++ b/gopipe/x264_decoder_test.go
@@ -110,9 +110,7 @@ func TestH264DecodeWithRTP(t *testing.T) {
 			ClockRate: 90_000,
 			Codec:     codec.H264,
 		}
-		pacer := &FrameSpacer{
-			Ctx: ctx,
-		}
+		pacer := NewFrameSpacer(ctx)
 		frameInter := newFrameInterceptor(false, 0, nil)
 
 		writer, err := Chain(i, sink, pacer, packetizer, encoder, frameInter)

--- a/simulation/quic_fake_codec_test.go
+++ b/simulation/quic_fake_codec_test.go
@@ -174,9 +174,9 @@ func runFakeSender(ctx context.Context, quicConn *quictransport.Transport) error
 		ClockRate: 90_000,
 		Codec:     codec.FAKE,
 	}
-	pacer := &gopipe.FrameSpacer{
-		Ctx: ctx,
-	}
+	pacer := gopipe.NewFrameSpacer(ctx)
+	defer pacer.Close()
+
 	rtpPipeline, err := gopipe.Chain(i, appSink, pacer, packetizer)
 	if err != nil {
 		return err

--- a/simulation/quic_h264_test.go
+++ b/simulation/quic_h264_test.go
@@ -179,8 +179,9 @@ func runH264Sender(ctx context.Context, quicConn *quictransport.Transport) error
 		return err
 	}
 
+	sendCodec := codec.H264
 	i := fileSrc.GetInfo()
-	encoder := gopipe.NewEncoder(codec.H264)
+	encoder := gopipe.NewEncoder(sendCodec)
 
 	// set rate callbacks
 	quicConn.SetSourceTargetRate = func(ratebps uint) error {
@@ -196,11 +197,11 @@ func runH264Sender(ctx context.Context, quicConn *quictransport.Transport) error
 		PT:        96,
 		SSRC:      0,
 		ClockRate: 90_000,
-		Codec:     codec.H264,
+		Codec:     sendCodec,
 	}
-	pacer := &gopipe.FrameSpacer{
-		Ctx: ctx,
-	}
+	pacer := gopipe.NewFrameSpacer(ctx)
+	defer pacer.Close()
+
 	rtpPipeline, err := gopipe.Chain(i, appSink, pacer, packetizer, encoder)
 	if err != nil {
 		return err
@@ -239,7 +240,8 @@ func runH264Receiver(ctx context.Context, quicConn *quictransport.Transport, wg 
 	}
 	defer rtpSrc.Close()
 
-	decoder, err := gopipe.NewDecoder(codec.H264)
+	recvCodec := codec.H264
+	decoder, err := gopipe.NewDecoder(recvCodec)
 	if err != nil {
 		return err
 	}
@@ -251,7 +253,7 @@ func runH264Receiver(ctx context.Context, quicConn *quictransport.Transport, wg 
 	defer fileSink.Close()
 
 	maxTimeout := 150 * time.Millisecond
-	depacketizer, err := gopipe.NewRTPDepacketizer(maxTimeout, codec.H264)
+	depacketizer, err := gopipe.NewRTPDepacketizer(maxTimeout, recvCodec)
 	if err != nil {
 		return err
 	}

--- a/subcmd/receive_go.go
+++ b/subcmd/receive_go.go
@@ -50,7 +50,7 @@ func (r *ReceiveGo) Exec(cmd string, args []string) error {
 	fs.StringVar(&r.localAddr, "local", "127.0.0.1", "Local address")
 	fs.StringVar(&r.remoteAddr, "remote", "127.0.0.1", "Remote address")
 	fs.BoolVar(&r.roqServer, "roq-server", false, "Use RoQ server transport.")
-	fs.StringVar(&r.codec, "codec", mrtp.H264.String(), "Codec to use (H264, VP8)")
+	fs.StringVar(&r.codec, "sink-codec", mrtp.H264.String(), "Codec to use (H264, VP8)")
 	fs.BoolVar(&r.qlog, "log-quic", false, "Log quic internal events")
 	fs.BoolVar(&r.traceRTP, "trace-rtp-recv", false, "Log incoming RTP packets")
 	fs.BoolVar(&r.datachannel, "dc", false, "Send/Receive data with data channels")

--- a/subcmd/send_go.go
+++ b/subcmd/send_go.go
@@ -59,7 +59,7 @@ func (s *SendGo) Exec(cmd string, args []string) error {
 	fs.UintVar(&s.roqMapping, "roq-mapping", 0, "RTP mapping to QUIC. 0: datagrams, 1: stream per packet, 2: single stream")
 	fs.BoolVar(&s.roqServer, "roq-server", false, "Usr RoQ server transport")
 	fs.StringVar(&s.sourceLocation, "source-location", "", "Location for filesource")
-	fs.StringVar(&s.codec, "codec", mrtp.H264.String(), "Codec to use (H264, VP8)")
+	fs.StringVar(&s.codec, "source-codec", mrtp.H264.String(), "Codec to use (H264, VP8)")
 	fs.BoolVar(&s.qlog, "log-quic", false, "Log quic internal events")
 	fs.BoolVar(&s.nada, "nada", false, "Enable NADA congestion control")
 	fs.BoolVar(&s.gcc, "pion-gcc", false, "Enable GCC congestion control")
@@ -232,9 +232,7 @@ Flags:
 		ClockRate: 90_000,
 		Codec:     codecTyp,
 	}
-	pacer := &gopipe.FrameSpacer{
-		Ctx: ctx,
-	}
+	pacer := gopipe.NewFrameSpacer(ctx)
 	rtpPipeline, err := gopipe.Chain(i, appSink, pacer, packetizer, encoder)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixed it by adding a close function to gopipe FrameSpacer.
Also made the codec names of send_go and receive_go consistent with the rest.