### PR TITLE
:bug::arrow_up:Fix emulation NADA problems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mengelbart/mrtp
 go 1.25.2
 
 require (
-	github.com/Willi-42/go-nada v0.0.0-20260508095559-fac583477c2d
+	github.com/Willi-42/go-nada v0.0.0-20260603113220-d44d60c19f5b
 	github.com/go-gst/go-glib v1.4.0
 	github.com/go-gst/go-gst v1.4.0
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/Willi-42/go-nada v0.0.0-20260508095559-fac583477c2d h1:nWwLRTlywAp6CNWxDRTdKpxZRvrqpLBOvtQJkuTZScQ=
-github.com/Willi-42/go-nada v0.0.0-20260508095559-fac583477c2d/go.mod h1:xXd7YylJIQGoI/UrznygfPjwxRsQKlnzSqHYuGS1Si4=
+github.com/Willi-42/go-nada v0.0.0-20260603113220-d44d60c19f5b h1:SVJ2wTB67EZR5dcZQ4xJtjeNseBz/fyzdfTwwJLUEUg=
+github.com/Willi-42/go-nada v0.0.0-20260603113220-d44d60c19f5b/go.mod h1:xXd7YylJIQGoI/UrznygfPjwxRsQKlnzSqHYuGS1Si4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/quictransport/tracer.go
+++ b/internal/quictransport/tracer.go
@@ -81,7 +81,7 @@ func (t *tracer) record(ts time.Time, event qlogwriter.Event) {
 				previous := time.Time{}
 				for _, tsRange := range f.ReceiveTimestamps {
 					for j, delta := range tsRange.TimestampDelta {
-						seqNr := uint64(f.LargestAcked()) - uint64(j)
+						seqNr := uint64(f.LargestAcked()) - tsRange.DeltaLargestAcknowledged - uint64(j)
 						delta := time.Duration(delta) * time.Microsecond
 						var arrival time.Time
 						if previous.IsZero() {


### PR DESCRIPTION
Addresses the emulation problems of #138 .

1. fixes the seqNr reconstruction in the quic tracer
2. Uses NADA version which can handle a negative time shift
