### PR TITLE
Hide simulation behind build tags

### DIFF
--- a/simulation/helper.go
+++ b/simulation/helper.go
@@ -1,3 +1,5 @@
+//go:build go1.25 && simulation
+
 package simulation
 
 import (

--- a/simulation/quic_dc_test.go
+++ b/simulation/quic_dc_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25 && simulation
+
 package simulation
 
 import (

--- a/simulation/quic_fake_codec_test.go
+++ b/simulation/quic_fake_codec_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25 && simulation
+
 package simulation
 
 import (

--- a/simulation/quic_h264_test.go
+++ b/simulation/quic_h264_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25 && simulation
+
 package simulation
 
 import (


### PR DESCRIPTION
This allows running unit tests without simulation. Simulation can be run explicitly with
```
go test -tags simulation ./...
```